### PR TITLE
macos build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .claude/
 \# Ignore accidental Windows device-name file
 nul
+build/

--- a/README.md
+++ b/README.md
@@ -225,3 +225,84 @@ Once all items are checked, you should be able to enjoy the game! 🎮
 **Version**: 1.0  
 **Last Updated**: December 2024  
 **Compatible**: Windows 10/11, Visual Studio 2019/2022
+
+---
+
+## 🍎 macOS Setup (vcpkg + Ninja)
+
+### 1) Install Tools
+
+```bash
+brew install cmake ninja
+```
+
+### 2) Install vcpkg
+
+```bash
+git clone https://github.com/microsoft/vcpkg.git "$HOME/vcpkg"
+"$HOME/vcpkg"/bootstrap-vcpkg.sh
+```
+
+Note: you do NOT need to `vcpkg install ...` manually — manifest mode (`vcpkg.json`) will resolve dependencies during CMake configure.
+
+Optional: set default triplet for convenience
+
+```bash
+# On Apple Silicon (arm64)
+export VCPKG_DEFAULT_TRIPLET=arm64-osx
+
+# On Intel (x86_64)
+# export VCPKG_DEFAULT_TRIPLET=x64-osx
+```
+
+### 3) Build with helper script (recommended)
+
+```bash
+cd path/to/potatogame_group3
+chmod +x ./build-macos.sh
+./build-macos.sh                      # native Debug build for your host arch
+./build-macos.sh --config Release     # native Release build
+```
+
+Advanced: universal build (for both arm64 and x86_64)
+
+```bash
+./build-macos.sh --arch universal --config Release
+```
+
+Custom vcpkg location:
+
+```bash
+./build-macos.sh --vcpkg-root "$HOME/dev/vcpkg"
+```
+
+### 4) Build with raw CMake (alternative)
+
+Apple Silicon:
+```bash
+cmake -G Ninja -S . -B build/macos-arm64-ninja \
+  -DCMAKE_TOOLCHAIN_FILE="$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
+  -DCMAKE_OSX_ARCHITECTURES=arm64
+cmake --build build/macos-arm64-ninja
+```
+
+Intel:
+```bash
+cmake -G Ninja -S . -B build/macos-x64-ninja \
+  -DCMAKE_TOOLCHAIN_FILE="$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
+  -DCMAKE_OSX_ARCHITECTURES=x86_64
+cmake --build build/macos-x64-ninja
+```
+
+Run (from the build dir):
+
+```bash
+./BrotatoGame
+```
+
+Notes:
+- Uses dynamic libraries from vcpkg by default — simplest for development.
+- `find_package(SDL2*_CONFIG REQUIRED)` already works with vcpkg toolchain.
+- If later you need a distributable `.app` or advanced universal packaging, we can extend the build.

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure we run from the repo root (script's directory)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Simple macOS build helper for CMake + Ninja + vcpkg
+# Defaults:
+#  - Detect host arch (arm64/x86_64) and build natively
+#  - macOS deployment target 12.0
+#  - Ninja generator
+#  - Debug config (override with --config Release)
+
+usage() {
+  cat <<'USAGE'
+Usage: ./build-macos.sh [--arch arm64|x86_64|universal] [--config Debug|Release] [--vcpkg-root PATH] [--clean]
+
+Options:
+  --arch         Target arch. Default: host arch. Use 'universal' for arm64;x86_64
+  --config       CMake build type. Default: Debug
+  --vcpkg-root   Path to vcpkg root (directory containing 'vcpkg' executable)
+  --clean        Remove build directory before configure
+
+Examples:
+  ./build-macos.sh                                     # native debug build
+  ./build-macos.sh --config Release                    # native release build
+  ./build-macos.sh --arch universal --config Release   # universal release build
+  ./build-macos.sh --vcpkg-root "$HOME/vcpkg"          # custom vcpkg path
+USAGE
+}
+
+ARCH=""
+CONFIG="Debug"
+VCPKG_ROOT="${VCPKG_ROOT:-}"
+CLEAN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage; exit 0;;
+    --arch)
+      ARCH="${2:-}"; shift 2;;
+    --config)
+      CONFIG="${2:-}"; shift 2;;
+    --vcpkg-root)
+      VCPKG_ROOT="${2:-}"; shift 2;;
+    --clean)
+      CLEAN=1; shift;;
+    *)
+      echo "Unknown option: $1" >&2; usage; exit 1;;
+  esac
+done
+
+# Detect host arch if not provided
+if [[ -z "$ARCH" ]]; then
+  HOST_ARCH=$(uname -m)
+  case "$HOST_ARCH" in
+    arm64) ARCH="arm64" ;;
+    x86_64) ARCH="x86_64" ;;
+    *) echo "Unsupported host arch: $HOST_ARCH" >&2; exit 1;;
+  esac
+fi
+
+# Resolve vcpkg root
+if [[ -z "$VCPKG_ROOT" ]]; then
+  if [[ -d "$HOME/vcpkg" ]]; then
+    VCPKG_ROOT="$HOME/vcpkg"
+  elif [[ -d "./vcpkg" ]]; then
+    VCPKG_ROOT="$(pwd)/vcpkg"
+  else
+    echo "vcpkg not found. Set VCPKG_ROOT env or pass --vcpkg-root PATH" >&2
+    echo "Example: git clone https://github.com/microsoft/vcpkg.git $HOME/vcpkg && $HOME/vcpkg/bootstrap-vcpkg.sh" >&2
+    exit 1
+  fi
+fi
+
+TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+if [[ ! -f "$TOOLCHAIN_FILE" ]]; then
+  echo "Invalid VCPKG_ROOT (missing scripts/buildsystems/vcpkg.cmake): $VCPKG_ROOT" >&2
+  exit 1
+fi
+
+# Require Ninja
+if ! command -v ninja >/dev/null 2>&1; then
+  echo "Ninja is required. Install via: brew install ninja" >&2
+  exit 1
+fi
+
+# Compose CMake arguments
+OSX_DEPLOYMENT_TARGET="12.0"
+if [[ "$ARCH" == "universal" ]]; then
+  CMAKE_OSX_ARCHS="arm64;x86_64"
+  BUILD_DIR="build/macos-universal-ninja"
+else
+  CMAKE_OSX_ARCHS="$ARCH"
+  BUILD_DIR="build/macos-${ARCH}-ninja"
+fi
+
+if [[ $CLEAN -eq 1 && -d "$BUILD_DIR" ]]; then
+  rm -rf "$BUILD_DIR"
+fi
+mkdir -p "$BUILD_DIR"
+pushd "$BUILD_DIR" >/dev/null
+
+echo "Configuring (arch=$CMAKE_OSX_ARCHS, config=$CONFIG) ..."
+cmake -G Ninja \
+  -DCMAKE_BUILD_TYPE="$CONFIG" \
+  -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET="$OSX_DEPLOYMENT_TARGET" \
+  -DCMAKE_OSX_ARCHITECTURES="$CMAKE_OSX_ARCHS" \
+  ../..
+
+echo "Building ..."
+cmake --build . -- -j "$(sysctl -n hw.ncpu)"
+
+echo
+echo "Done. Executable is in: $BUILD_DIR"
+echo "To run: $(pwd)/BrotatoGame"
+
+popd >/dev/null
+
+


### PR DESCRIPTION
macos build support

prompt:
помоги мне добавить возможность сборки под macos. Сохрани возможность собирать под win. Учти что в будущем еще будет сборка под андроид, но это позже и отдельная задача. Спроси меня вопросы ответы на которые помогут тебе всё правильно реализовать

answers:
1. vcpkg
2. оба, в том смысле что бы разработчик мог собрать на своей arm либо intel машине, 12 норм
3. достаточно что бы собиралось у разработчика
4. как проще для разработчиков так лучше
5. ninja
6. не важно
7. нет

Result:
Супер, принял ответы. План уточнен: делаю минимальные изменения без ломки Win, добавляю удобный скрипт под macOS и инструкции. Уже сделал.
Что сделал сейчас
Добавил скрипт сборки macOS с vcpkg и Ninja: build-macos.sh. Поддерживает:
--arch arm64|x86_64|universal (по умолчанию — автодетект по хосту)
--config Debug|Release (по умолчанию Debug)
--vcpkg-root PATH и --clean
macOS 12.0 как минимальную версию и Ninja-генератор
Обновил README.md: пошаговая инструкция для macOS (brew → vcpkg → запуск скрипта), примеры для arm64/x86_64 и альтернативный вызов CMake напрямую.
Windows-сборка не тронута.
Как пользоваться на macOS
Установите инструменты:
brew install cmake ninja
vcpkg: git clone https://github.com/microsoft/vcpkg.git "$HOME/vcpkg" && "$HOME/vcpkg"/bootstrap-vcpkg.sh
Сборка:
В корне проекта:
chmod +x ./build-macos.sh
./build-macos.sh — нативная Debug-сборка под вашу архитектуру
./build-macos.sh --config Release — Release
опционально: ./build-macos.sh --arch universal --config Release (продвинуто, может потребовать отдельной настройки vcpkg под universal)
Альтернатива (без скрипта), пример для Apple Silicon:
cmake -G Ninja -S . -B build/macos-arm64-ninja -DCMAKE_TOOLCHAIN_FILE="$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake" -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 -DCMAKE_OSX_ARCHITECTURES=arm64
cmake --build build/macos-arm64-ninja
Вопросы/подтверждения перед тем как закрыть задачу
Ок оставить SDL_WINDOW_FULLSCREEN_DESKTOP на macOS как есть?
Нужны ли пресеты (CMakePresets.json) сейчас, или оставляем скрипт?
Хотите ли в ближайшее время добавить GitHub Actions для macOS (Ninja + vcpkg) — могу подготовить потом.
Короткие заметки
Никаких изменений в CMakeLists.txt не потребовалось: find_package(SDL2*_CONFIG REQUIRED) корректно работает с vcpkg toolchain на macOS.
Универсальная сборка — опционал. Для разработки достаточно, что каждый разработчик собирает под свою архитектуру (arm64/x86_64), это уже поддержано.
Итог
Добавлен build-macos.sh с поддержкой arm64/x86_64 и Ninja, автонастройкой vcpkg toolchain.
README.md дополнен разделом по macOS.
Windows-сборка работает как раньше.

